### PR TITLE
feat: update codecov action to v4

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -52,9 +52,14 @@ on:
         default: npm run test-only
         required: false
       upload-coverage:
-        description: Whether to run the Codecov action to upload coverage data.
+        description: >
+          Whether to run the Codecov action to upload coverage data.
+          This requires to pass the `codecov-token` secret.
         type: boolean
-        default: true
+        default: false
+        required: false
+    secrets:
+      codecov-token:
         required: false
 
 jobs:
@@ -77,6 +82,13 @@ jobs:
             fi
           fi
           echo "npm-final-setup-command=$SETUP_COMMAND" >> $GITHUB_OUTPUT
+      - name: Check codecov token
+        if: ${{ inputs.upload-coverage }}
+        run: |
+          if [ "${{ secrets.codecov-token }}" = "" ]; then
+            echo "The 'codecov-token' secret must be passed in order to upload coverage data."
+            exit 1
+          fi
   lint-eslint:
     if: ${{ inputs.lint-eslint }}
     needs: prepare
@@ -139,4 +151,7 @@ jobs:
         run: ${{ inputs.npm-test-command }}
       - name: Send coverage report to Codecov
         if: ${{ inputs.upload-coverage }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.codecov-token }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Inputs:
   * Default: `npm run test-only`
 * **upload-coverage**:
   * Whether to run the Codecov action to upload coverage data.
-  * Default: `true`
+    This requires to pass the `codecov-token` secret.
+  * Default: `false`
 
 Example usage for a TypeScript project:
   
@@ -66,6 +67,9 @@ jobs:
     uses: zakodium/workflows/.github/workflows/nodejs.yml@nodejs-v1
     with:
       lint-check-types: true
+      upload-coverage: true
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ### Release


### PR DESCRIPTION
The coverage upload must be disabled by default because it
requires a token to be passed from the parent workflow.

Closes: https://github.com/zakodium/workflows/issues/7

Tests done on test package with this branch: https://github.com/cheminfo/test-package/pull/15
- Update to v4 without token: https://github.com/cheminfo/test-package/actions/runs/8168839748/job/22331715346
  Tests passed but you can see in the logs that the upload failed (That was before setting the `fail_ci_if_error` option).
- Token check with early fail: https://github.com/cheminfo/test-package/actions/runs/8169041403/job/22332528085
- With valid token: https://github.com/cheminfo/test-package/actions/runs/8169127639/job/22332569375
  Coverage was uploaded: https://app.codecov.io/github/cheminfo/test-package/commit/6075f6b9599a52bb703e3c71d8c4432d6dce37f9/tree