### PR TITLE
fix: avoid huge default action timeout

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -66,6 +66,7 @@ jobs:
   prepare:
     if: ${{ inputs.lint-eslint || inputs.lint-prettier || inputs.lint-check-types || !inputs.disable-tests }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       npm-final-setup-command: ${{ steps.get-command.outputs.npm-final-setup-command }}
     steps:
@@ -93,6 +94,7 @@ jobs:
     if: ${{ inputs.lint-eslint }}
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -106,6 +108,7 @@ jobs:
     if: ${{ inputs.lint-prettier }}
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -119,6 +122,7 @@ jobs:
     if: ${{ inputs.lint-check-types }}
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -132,6 +136,7 @@ jobs:
     if: ${{ !inputs.disable-tests }}
     needs: prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: ${{ fromJson(inputs.node-version-matrix) }}

--- a/.github/workflows/npm-prerelease.yml
+++ b/.github/workflows/npm-prerelease.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       continue: ${{ steps.validation.outputs.continue }}
       npm-final-setup-command: ${{ steps.get-command.outputs.npm-final-setup-command }}
@@ -59,6 +60,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.continue }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       npm-final-setup-command: ${{ steps.get-command.outputs.npm-final-setup-command }}
@@ -88,6 +89,7 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created && inputs.npm && (needs.release-please.outputs.publish_npm=='true' || needs.release-please.outputs.publish_github=='true') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Set a custom timeout for each job, otherwise it's 6 hours by default.

- 5 minutes for simple jobs
- 10 minutes if `npm install` is involved
- 30 minutes for tests
