### PR TITLE
feat: add input for checking out submodules

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,6 +48,11 @@ on:
         description: GitHub ref to checkout.
         type: string
         required: false
+      checkout-submodules:
+        description: Whether submodules should be initialized during checkout.
+        type: boolean
+        required: false
+        default: false
     secrets:
       registry-token:
         required: false
@@ -65,6 +70,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+          submodules: ${{ inputs.checkout-submodules }}
       - name: Determine Docker tags
         id: get-tags
         run: |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ This workflow allows to build and push a Docker image to some registry. It can h
 * **ref**:
   * GitHub ref to checkout.
   * Default: Ref that corresponds to the triggering event.
+* **checkout-submodules**:
+  * Whether submodules should be initialized during checkout.
+  * Default `false`
 
 #### Secrets
 


### PR DESCRIPTION
rest-on-couch images for projects use submodules to clone database configurations, for example https://github.com/cheminfo/roc-eln-config